### PR TITLE
docs: Streamline README for end users

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,54 +5,42 @@
 [![CRAN status](https://www.r-pkg.org/badges/version/mcpr)](https://CRAN.R-project.org/package=mcpr)
 <!-- badges: end -->
 
-The goal of mcpr is to expose R functions, files, or entire packages through the Model Context Protocol (MCP). This allows R code to integrate seamlessly with AI assistants like Claude Desktop.
+mcpr exposes R functions through the Model Context Protocol (MCP), enabling seamless integration with AI assistants like Claude Desktop.
 
 ## Installation
 
-You can install the development version of mcpr from GitHub:
-
-``` r
+```r
 # install.packages("devtools")
 devtools::install_github("chi2labs/mcpr")
 ```
 
-## Basic Usage
+## Quick Start
 
-### Method 1: Programmatic API
-
-Create a simple MCP server with tools and resources:
+### Basic Server
 
 ```r
 library(mcpr)
 
-# Create a new HTTP MCP server
-server <- mcp_http(name = "My R Analysis Server", version = "1.0.0", port = 8080)
+# Create and configure server
+server <- mcp_http("My R Analysis Server", "1.0.0", port = 8080)
 
-# Add a tool
+# Add tools
 server$mcp_tool(
   name = "calculate_mean",
   fn = function(numbers) mean(numbers),
   description = "Calculate the mean of a numeric vector"
 )
 
-# Add a resource
-server$mcp_resource(
-  name = "info",
-  fn = function() "This server provides statistical analysis tools",
-  description = "Server information"
-)
-
-
-# Run the server with HTTP transport (recommended)
-server$mcp_run(transport = "http", port = 8080)
+# Run server
+server$mcp_run()
 ```
 
-### Method 2: Decorator Syntax
+### Using Decorators
 
-Use plumber-style decorators to define MCP tools, resources, and prompts:
+Create a file with decorated functions:
 
 ```r
-# Create a file: analysis-tools.R
+# analysis-tools.R
 #* @mcp_tool
 #* @description Calculate summary statistics for a numeric vector
 #* @param x numeric vector to analyze
@@ -66,46 +54,19 @@ calculate_stats <- function(x, na.rm = TRUE) {
     max = max(x, na.rm = na.rm)
   )
 }
-
-#* @mcp_resource
-#* @description List available datasets
-#* @mime_type application/json
-list_datasets <- function() {
-  data(package = "datasets")$results[, "Item"]
-}
-
-#* @mcp_prompt
-#* @description Request statistical analysis
-#* @template Analyze the {{dataset}} dataset using {{method}} and provide insights about {{focus}}
-#* @param_dataset The dataset to analyze
-#* @param_method The analysis method to use
-#* @param_focus The aspect to focus on
-statistical_analysis_prompt <- NULL
 ```
 
-Load decorated functions into a server:
+Load and run:
 
 ```r
-# Create server and load decorated functions
-server <- mcp(name = "Analysis Server", version = "1.0.0")
+server <- mcp("Analysis Server", "1.0.0")
 server$mcp_source("analysis-tools.R")
-
-# Run with HTTP transport
 server$mcp_run(transport = "http", port = 8080)
-```
-
-See the complete example at `inst/examples/decorated-functions.R`.
-
-## Generating Standalone MCP Servers
-=======
-# Run the server
-server$mcp_run()
 ```
 
 ## Configure Claude Desktop
 
-
-Add your server to Claude Desktop's configuration:
+Add to Claude Desktop's configuration:
 
 ```json
 {
@@ -117,35 +78,13 @@ Add your server to Claude Desktop's configuration:
 }
 ```
 
-## HTTP Transport
+## Advanced Usage
 
-mcpr uses HTTP transport as the primary method for MCP communication, offering several advantages:
-
-- **Multiple clients**: Handle concurrent connections
-- **Standard debugging**: Use curl, Postman, or browser tools
-- **Easy deployment**: Deploy to cloud platforms or containers
-- **Built-in logging**: Track requests and errors
-- **Reliable communication**: No subprocess or stdin/stdout issues
-
-### Quick Start
+### Register Existing Functions
 
 ```r
-# Start a hello world HTTP server
-mcp_hello_world_http(port = 8080)
+server <- mcp_http("Stats Server", "1.0.0")
 
-# Test with curl:
-# curl -X POST http://localhost:8080/mcp \
-#   -H "Content-Type: application/json" \
-#   -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
-```
-
-### Creating Servers from Functions
-
-```r
-# Create server with multiple tools
-server <- mcp_http("Stats Server", "1.0.0", port = 8080)
-
-# Register existing R functions
 server$mcp_tool(
   name = "t_test",
   fn = t.test,
@@ -153,47 +92,15 @@ server$mcp_tool(
 )
 
 server$mcp_tool(
-  name = "cor_test",
+  name = "cor_test", 
   fn = cor.test,
   description = "Correlation test"
 )
-
-# Start the server
-server$mcp_run()
-```
-
-### Using Decorators (Coming Soon)
-
-```r
-#* @mcp_tool
-#* @description Calculate summary statistics
-#* @param data A numeric vector
-calculate_stats <- function(data) {
-  list(mean = mean(data), sd = sd(data))
-}
-
-# Load decorated functions
-server <- mcp_http()
-server$source("analysis_functions.R")
-server$mcp_run(port = 8080)
-```
-
-## Deployment Options
-
-### Local Development
-Run the server locally for Claude Desktop:
-
-```r
-server <- mcp_http("My Server", "1.0.0")
-# ... add tools ...
-server$mcp_run(port = 8080)
 ```
 
 ### Production Deployment
-Deploy to production environments:
 
 ```r
-# Configure for production
 server <- mcp_http(
   name = "Production Server",
   version = "1.0.0",
@@ -202,15 +109,9 @@ server <- mcp_http(
   log_file = "mcp-server.log",
   log_level = "info"
 )
-
-# Add authentication (coming soon)
-# server$use_auth(api_key = Sys.getenv("MCP_API_KEY"))
-
-server$mcp_run()
 ```
 
 ### Docker Deployment
-Create a Dockerfile for your MCP server:
 
 ```dockerfile
 FROM rocker/r-ver:4.3.0
@@ -221,39 +122,12 @@ EXPOSE 8080
 CMD ["Rscript", "server.R"]
 ```
 
+## Examples
 
-## Example Servers
-
-See the `inst/examples/` directory for complete examples:
+Complete examples in `inst/examples/`:
 - `basic-server.R` - Simple server with basic tools
 - `stats-server.R` - Statistical analysis tools
 - `data-server.R` - Data manipulation and visualization
-
-## Development
-
-To run tests:
-
-```r
-devtools::test()
-```
-
-To build documentation:
-
-```r
-devtools::document()
-pkgdown::build_site()
-```
-
-## Technical Notes
-
-### JSON Serialization
-When implementing MCP servers, mcpr handles proper JSON serialization including:
-- Automatic scalar unboxing for cleaner JSON
-- Protection of empty arrays to ensure they serialize as `[]` not `{}`
-- Proper handling of R's special values (NA, NULL, Inf)
-
-### Error Handling
-The HTTP transport provides clean error responses following the JSON-RPC 2.0 specification, making debugging easier compared to stdio transport.
 
 ## License
 


### PR DESCRIPTION
## Summary
Streamlined the README to be more concise and focused on end-user needs, removing development-related content and duplications.

## Changes
- **Reduced size**: From 260 to 133 lines (49% reduction)
- **Removed duplications**: 
  - Duplicate "Run the server" section
  - Redundant decorator examples
  - Overlapping server creation examples
- **Removed development content**:
  - Development section with test/build commands
  - Technical Notes about internal implementation
  - "(Coming Soon)" features already demonstrated
- **Improved clarity**:
  - Single concise introduction
  - Streamlined examples
  - Clear focus on user-facing features

## Result
The README now provides a clean, focused guide for end users without internal development information, making it easier to get started with mcpr.

🤖 Generated with [Claude Code](https://claude.ai/code)